### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It was vibe coded using ChatGTP. Feel free to burn the code, change it or rewrit
 ## Installation
 
 ```bash
-go install github.com/giantswarm/waluigi
+go install github.com/giantswarm/waluigi@latest
 ```
 
 ## Usage


### PR DESCRIPTION
The `go install` command requires a `@latest` parameter.

```
$ go install github.com/giantswarm/waluigi
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/giantswarm/waluigi@latest' to install the latest version
```